### PR TITLE
use sha1 digest for creation of ids from variable,entity and study.

### DIFF
--- a/R/Study-methods.R
+++ b/R/Study-methods.R
@@ -166,7 +166,7 @@ setMethod("set_study_name", "Study", function(study, name) {
 setMethod("get_study_id", "Study", function(study) {
   name <- study %>% get_study_name()
   if (is_truthy(name)) {
-    return(generate_alphanumeric_id(seed_string = name))
+    return(prefixed_alphanumeric_id(seed_string=name, prefix="STUDY_", length=10))
   } else {
     stop("Error: not allowed to call get_study_id() on a study with no name.")
   }
@@ -184,11 +184,11 @@ setMethod("get_study_id", "Study", function(study) {
 #' @return A `character` string representing a short generated unique ID for the study for use in table names.
 #' @export
 setMethod("get_study_abbreviation", "Study", function(study) {
-  id <- study %>% get_study_id()
-  if (is_truthy(id)) {
-    return(generate_alphanumeric_id(seed_string = id, length = 8))
+  name <- study %>% get_study_name()
+  if (is_truthy(name)) {
+    return(generate_alphanumeric_id(seed_string=name, length = 10))
   } else {
-    stop("Error: not allowed to call get_study_abbreviation() on a study with no study_id.")
+    stop("Error: not allowed to call get_study_abbreviation() on a study with no study name.")
   }
 })
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,6 @@
 library(glue)
 library(knitr)
+library(digest)
 
 #' skimr shortens all factor names to three characters by default.
 #' Create a custom skimmer that doesn't do this and trims top counts to 5.
@@ -346,30 +347,7 @@ check_and_convert_to_date <- function(data, column_name) {
 generate_alphanumeric_id <- function(length = 11, seed_string = NULL) {
   # Seed the RNG if a seed string is provided
   if (!is.null(seed_string)) {
-    char_values <- utf8ToInt(seed_string)
-    
-    # Define a sequence of prime numbers (at least as long as the string)
-    primes <- c(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71)
-    
-    # If the string is longer than the primes array, repeat the primes
-    if (length(char_values) > length(primes)) {
-      primes <- rep(primes, length.out = length(char_values))
-    }
-    
-    # Multiply each char value by the corresponding prime
-    seed <- sum(char_values * primes[seq_along(char_values)]) %% .Machine$integer.max
-    set.seed(seed)
-  }
-  
-  chars <- c(letters, LETTERS, 0:9)  # Define allowed characters
-  non_digit_chars <- c(letters, LETTERS)  # Characters to ensure non-digit start
-  
-  # Loop until the first character is non-digit
-  repeat {
-    result <- paste0(sample(chars, length, replace = TRUE), collapse = "")
-    if (substr(result, 1, 1) %in% non_digit_chars) {
-      return(result)
-    }
+    return(substring(digest(seed_string, alg="sha1", serialize=FALSE), 1, length))
   }
 }
 
@@ -383,9 +361,9 @@ generate_alphanumeric_id <- function(length = 11, seed_string = NULL) {
 #' @param seed_string Optional seed string for deterministic ID generation.
 #' @return A prefixed alphanumeric ID.
 #'
-prefixed_alphanumeric_id <- function(prefix = "", length = 11, seed_string = NULL) {
+prefixed_alphanumeric_id <- function(prefix = NULL, length = 11, seed_string = NULL) {
   # Ensure the prefix is non-empty and valid
-  if (!is.character(prefix) || length(prefix) != 1) {
+  if (!is.character(prefix)) {
     stop("The `prefix` argument must be a single character string.")
   }
   


### PR DESCRIPTION
The study_stable_id should be like "STUDY_XXXXXXXX"
the internal_abbrev for the study can be the same w/out the suffix


for entities and variables ... doesn't matter too much because these are all internal.  For study, I'd like to be consistent with how we do Dataset.  for example if i use the workflow resource name as the study name, i will get the same digest as for dataset records.  

TODO:  fix tests if broken.  I didnt' run them. 

If sha1_hex doesn't work for variables and/or entities.. please set it back the way it was for those.  