### PR TITLE
Ensure default collection.impute_zero is used in hydrated metadata

### DIFF
--- a/R/Entity-collections.R
+++ b/R/Entity-collections.R
@@ -297,6 +297,11 @@ setMethod("get_hydrated_collection_metadata", "Entity", function(entity) {
         is.na(stable_id),
         prefixed_alphanumeric_id(prefix = "COL_", length = 8, seed_string = category),
         stable_id
+      ),
+      impute_zero = if_else(
+        is.na(impute_zero),
+        collection_metadata_defaults$impute_zero,
+        impute_zero
       )
     ) %>%
     ungroup()

--- a/tests/testthat/_snaps/Study-export-VDI.md
+++ b/tests/testthat/_snaps/Study-export-VDI.md
@@ -1550,7 +1550,7 @@
       H003-P3	VAR_e301dd60	Male		
       
       ##  collection_sde41bbea90_observtn.cache 
-      COL_60b0b28d	integer-based anatomical measures	2			32	175		integer	continuous		0	0	0		measurement	measurements
+      COL_60b0b28d	integer-based anatomical measures	2			32	175	0	integer	continuous		0	0	0		measurement	measurements
       
       ##  collectionattribute_sde41bbea90_observtn.cache 
       COL_60b0b28d	VAR_0789e56a


### PR DESCRIPTION
If child variables have the default `impute_zero = NA` the collection wrongly inherits this (in `get_hydrated_collection_metadata()`) even though a default (`FALSE`) is specified for collections at the top of `R/Entity-collections.R`.

This fixes that and adds a test to make sure.