### PR TITLE
Allow boolean/logical data columns, detect true/false yes/no as binary shape, validate newlines and >1000 chars

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: study.wrangler
 Title: Wrangle (Tidy) Study Data
-Version: 1.0.34
+Version: 1.0.35
 Authors@R:
     c(person(given = "Bob",
            family = "MacCallum",

--- a/R/Entity-methods.R
+++ b/R/Entity-methods.R
@@ -135,22 +135,43 @@ function(
 #' @returns modified entity
 setMethod("infer_missing_data_shapes", "Entity", function(entity) {
   variables <- entity@variables
-  
+  data <- entity@data
+
   # only infer for data_shape == NA and non-ID cols
   cols_to_infer <- variables %>%
     filter(is.na(data_shape)) %>%
     filter(!is.na(data_type)) %>%
     filter(!data_type %in% c('id', 'category')) %>%
     pull(variable)
-  
-  # infer data_shape as continuous or categorical
+
+  # detect boolean-like string columns and mark as 'binary'
+  # two-step: (1) exactly 2 distinct non-NA values, (2) those values folded to
+  # lowercase form one of the recognised boolean pairs
+  boolean_pairs <- list(c('true', 'false'), c('t', 'f'), c('yes', 'no'), c('y', 'n'))
+
+  is_boolean_col <- function(col) {
+    non_na <- data[[col]][!is.na(data[[col]])]
+    unique_vals <- unique(non_na)
+    if (length(unique_vals) != 2) return(FALSE)
+    folded <- sort(tolower(unique_vals))
+    any(vapply(boolean_pairs, function(pair) identical(folded, sort(pair)), logical(1)))
+  }
+
+  string_cols_to_infer <- variables %>%
+    filter(variable %in% cols_to_infer, data_type == "string", !is_multi_valued) %>%
+    pull(variable)
+
+  binary_cols <- string_cols_to_infer[vapply(string_cols_to_infer, is_boolean_col, logical(1))]
+
+  # infer data_shape as continuous, binary, or categorical
   # (further refinement to 'ordinal' will require user-input)
   variables <- variables %>% mutate(
     data_shape = if_else(
       variable %in% cols_to_infer,
       case_when(
         data_type %in% c('number', 'integer', 'date') ~ fct_mutate(data_shape, 'continuous'),
-        TRUE ~ fct_mutate(data_shape, 'categorical')
+        variable %in% binary_cols                      ~ fct_mutate(data_shape, 'binary'),
+        TRUE                                           ~ fct_mutate(data_shape, 'categorical')
       ),
       data_shape
     )

--- a/R/entity-validators-data-types.R
+++ b/R/entity-validators-data-types.R
@@ -358,6 +358,47 @@ validate_entity_string_data_shapes <- function(entity) {
   list(valid = TRUE)
 }
 
+#' Validator: Check binary variables have at most 2 unique values
+#' @keywords internal
+validate_entity_binary_value_count <- function(entity) {
+  data <- entity@data
+  variables <- entity@variables
+
+  binary_columns <- variables %>%
+    filter(data_shape == "binary", !is_multi_valued) %>%
+    pull(variable)
+
+  if (length(binary_columns) == 0) return(list(valid = TRUE))
+
+  too_many_values <- binary_columns[vapply(binary_columns, function(col) {
+    n_distinct(data[[col]], na.rm = TRUE) > 2
+  }, logical(1))]
+
+  if (length(too_many_values) == 0) return(list(valid = TRUE))
+
+  global_varname <- find_global_varname(entity, 'entity')
+
+  messages <- sapply(too_many_values, function(col_name) {
+    n <- n_distinct(data[[col_name]], na.rm = TRUE)
+    paste0("Variable '", col_name, "' is declared as 'binary' but has ", n,
+           " unique values (binary variables must have exactly 2).")
+  })
+
+  fix_commands <- sapply(too_many_values, function(col_name) {
+    paste0("    ", global_varname, " <- ", global_varname,
+           " %>% set_variable_metadata('", col_name, "', data_shape = 'categorical')")
+  })
+
+  message <- paste(
+    paste(messages, collapse = "\n"),
+    "To fix these variables, set an appropriate data_shape:",
+    paste(fix_commands, collapse = "\n"),
+    sep = "\n"
+  )
+
+  list(valid = FALSE, fatal = FALSE, message = message)
+}
+
 #' Validator: Check ordinal levels consistency
 #' @keywords internal
 validate_entity_ordinal_levels <- function(entity) {

--- a/R/entity-validators-eda-basic.R
+++ b/R/entity-validators-eda-basic.R
@@ -73,3 +73,110 @@ validate_eda_variable_display_name_not_null <- function(entity) {
 
   list(valid = TRUE)
 }
+
+#' Validator: Check string variable values do not exceed 1000 characters
+#'
+#' The EDA backend stores string values in VARCHAR(1000). Values longer than
+#' 1000 characters will cause import failures.
+#' @keywords internal
+validate_entity_string_value_length <- function(entity) {
+  data <- entity@data
+  variables <- entity@variables
+
+  string_vars <- variables %>%
+    filter(data_type == "string") %>%
+    select(variable, is_multi_valued, multi_value_delimiter)
+
+  if (nrow(string_vars) == 0) return(list(valid = TRUE))
+
+  exceeds_limit <- function(col_name, is_mv, delim) {
+    vals <- data[[col_name]]
+    raw_lengths <- nchar(vals)
+    if (max(raw_lengths, na.rm = TRUE) <= 1000) return(FALSE)
+
+    if (!is_mv) return(TRUE)
+
+    # Two-stage check for multi-valued: only split rows where the raw cell
+    # exceeds 1000 chars (a necessary condition for any component to exceed it).
+    long_rows <- vals[!is.na(vals) & raw_lengths > 1000]
+    any(sapply(strsplit(long_rows, delim, fixed = TRUE), function(parts) any(nchar(parts) > 1000)))
+  }
+
+  too_long <- string_vars %>%
+    filter(pmap_lgl(list(variable, is_multi_valued, multi_value_delimiter), exceeds_limit)) %>%
+    pull(variable)
+
+  if (length(too_long) == 0) return(list(valid = TRUE))
+
+  global_varname <- find_global_varname(entity, 'entity')
+
+  messages <- sapply(too_long, function(col_name) {
+    is_mv <- string_vars %>% filter(variable == col_name) %>% pull(is_multi_valued)
+    delim  <- string_vars %>% filter(variable == col_name) %>% pull(multi_value_delimiter)
+    if (is_mv) {
+      vals <- unlist(strsplit(data[[col_name]][!is.na(data[[col_name]])], delim, fixed = TRUE))
+    } else {
+      vals <- data[[col_name]]
+    }
+    max_len <- max(nchar(vals), na.rm = TRUE)
+    paste0("Variable '", col_name, "' has values up to ", max_len,
+           " characters long (EDA backend limit is 1000).")
+  })
+
+  fix_commands <- sapply(too_long, function(col_name) {
+    paste0("    ", global_varname, " <- ", global_varname,
+           " %>% modify_data(mutate(", col_name, " = substr(", col_name, ", 1, 1000)))")
+  })
+
+  message <- paste(
+    paste(messages, collapse = "\n"),
+    "If appropriate for your data, truncate these values to 1000 characters:",
+    paste(fix_commands, collapse = "\n"),
+    sep = "\n"
+  )
+
+  list(valid = FALSE, fatal = FALSE, message = message)
+}
+
+#' Validator: Check string variable values do not contain newline characters
+#'
+#' Newlines in string values corrupt the TSV-based VDI import format.
+#' For multi-valued columns, checking the raw (unsplit) cell is sufficient:
+#' if no raw cell contains a newline, no component can either.
+#' @keywords internal
+validate_entity_string_value_newlines <- function(entity) {
+  data <- entity@data
+  variables <- entity@variables
+
+  string_cols <- variables %>%
+    filter(data_type == "string") %>%
+    pull(variable)
+
+  if (length(string_cols) == 0) return(list(valid = TRUE))
+
+  has_newlines <- string_cols[vapply(string_cols, function(col) {
+    any(grepl("\n|\r", data[[col]], perl = TRUE), na.rm = TRUE)
+  }, logical(1))]
+
+  if (length(has_newlines) == 0) return(list(valid = TRUE))
+
+  global_varname <- find_global_varname(entity, 'entity')
+
+  messages <- paste0("Variable '", has_newlines,
+                     "' contains newline characters, which will corrupt VDI import.")
+
+  fix_commands <- sapply(has_newlines, function(col_name) {
+    paste0("    ", global_varname, " <- ", global_varname,
+           " %>% modify_data(mutate(", col_name,
+           " = gsub(\"\\n|\\r\", \" \", ", col_name, ")))")
+  })
+
+  message <- paste(
+    paste(messages, collapse = "\n"),
+    "If appropriate for your data, replace newlines with spaces:",
+    paste(fix_commands, collapse = "\n"),
+    sep = "\n"
+  )
+
+  list(valid = FALSE, fatal = FALSE, message = message)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -120,7 +120,12 @@ type_convert_quietly <- function(data, guess_integer = TRUE, global_varname = 'e
 
     tryCatch(
       {
-        suppressMessages(readr::type_convert(tibble(value = column), guess_integer = guess_integer)$value)
+        result <- suppressMessages(readr::type_convert(tibble(value = column), guess_integer = guess_integer)$value)
+        # Do not allow readr to convert boolean strings to logical type.
+        # Boolean-like columns (TRUE/FALSE/T/F etc.) are kept as character
+        # and handled via binary data_shape detection in infer_missing_data_shapes().
+        if (is.logical(result)) return(column)
+        result
       },
       warning = function(w) {
         if (grepl("expected valid date", conditionMessage(w))) {

--- a/R/validators.R
+++ b/R/validators.R
@@ -217,6 +217,13 @@ list_validators <- function() {
    register_validator("eda_variable_display_name_not_null", validate_eda_variable_display_name_not_null,
                      "entity", "eda", "Validate display_name is not null for any variable")
 
+  # EDA string value validators
+  register_validator("eda_string_value_length", validate_entity_string_value_length,
+                    "entity", "eda", "Check string values do not exceed 1000 characters")
+
+  register_validator("eda_string_value_newlines", validate_entity_string_value_newlines,
+                    "entity", "eda", "Check string values do not contain newline characters")
+
   # Study-level EDA validators
   register_validator("study_unique_entity_stable_ids", validate_study_unique_entity_stable_ids,
                     "study", "eda", "Check that all entity stable_ids are unique across the study")

--- a/R/validators.R
+++ b/R/validators.R
@@ -163,6 +163,9 @@ list_validators <- function() {
   register_validator("entity_string_data_shapes", validate_entity_string_data_shapes,
                     "entity", "baseline", "Check string variables have appropriate data_shape")
 
+  register_validator("entity_binary_value_count", validate_entity_binary_value_count,
+                    "entity", "baseline", "Check binary variables have at most 2 unique values")
+
   register_validator("entity_date_data_types", validate_entity_date_data_types,
                     "entity", "baseline", "Check date variables are R date type")
   

--- a/tests/testthat/_snaps/Study-export-VDI.md
+++ b/tests/testthat/_snaps/Study-export-VDI.md
@@ -1434,8 +1434,8 @@
       H003	H003-P3
       
       ##  attributegraph_sde41bbea90_househld.cache 
+      		binary	string						default	2		1			0	0	0	0	0				ENT_6a7855ea		["Owns property"]				VAR_94999355				["No","Yes"]	
       		categorical	string						default	2		1			0	0	0	0	0				ENT_6a7855ea		["Construction material"]				VAR_3b2f7286				["Concrete","Timber"]	
-      		categorical	string						default	2		1			0	0	0	0	0				ENT_6a7855ea		["Owns property"]				VAR_94999355				["No","Yes"]	
       1		continuous	integer						default	2		1			0	0	0	0	0	3	3.33333333333333	3	ENT_6a7855ea	0	["Number of animals"]	4	3		VAR_1513b065		3.5			
       week		continuous	date						default	3		1			0	0	0	0	0	2021-02-03	2021-02-15	2021-02-28	ENT_6a7855ea		["Enrollment date"]	2021-03-13	2021-01-09		VAR_ec493713		2021-03-06			
       

--- a/tests/testthat/test-Entity-validate.R
+++ b/tests/testthat/test-Entity-validate.R
@@ -556,3 +556,33 @@ test_that("validate() catches string/integer mismatch that causes VDI export fai
   expect_true(households %>% validate())
 })
 
+test_that("validate() complains about binary variables with more than 2 unique values", {
+  file_path <- system.file("extdata", "toy_example/participants.tsv", package = 'study.wrangler')
+  participants <- entity_from_file(file_path, name = 'participant') %>%
+    quiet() %>%
+    redetect_columns_as_variables('Name') %>%
+    verbose()
+
+  # Should validate cleanly
+  expect_true(participants %>% validate())
+
+  # Force Family.Role (3 values: Relative, Child, Parent) to binary
+  participants <- participants %>%
+    quiet() %>%
+    set_variable_metadata('Family.Role', data_shape = 'binary') %>%
+    verbose()
+
+  # Validation should now fail with an informative message
+  expect_warning(
+    expect_false(validate(participants)),
+    "Family.Role.+binary.+3 unique values.+set_variable_metadata.+data_shape = 'categorical'"
+  )
+
+  # Fix it
+  participants <- participants %>%
+    quiet() %>%
+    set_variable_metadata('Family.Role', data_shape = 'categorical')
+
+  expect_true(participants %>% validate())
+})
+

--- a/tests/testthat/test-Entity-validate.R
+++ b/tests/testthat/test-Entity-validate.R
@@ -492,7 +492,7 @@ test_that("validate() complains about string columns with non-character data", {
       modify_data(mutate(Number.of.animals = as.character(Number.of.animals))) %>%
       set_variable_metadata('Number.of.animals', data_shape = 'categorical')
   )
-  expect_true(households %>% validate())
+  expect_true(households %>% quiet() %>% validate())
 })
 
 test_that("validate() complains about string variables with continuous data_shape", {
@@ -518,7 +518,7 @@ test_that("validate() complains about string variables with continuous data_shap
     quiet() %>%
     set_variable_metadata('Construction.material', data_shape = 'categorical')
 
-  expect_true(households %>% validate())
+  expect_true(households %>% quiet() %>% validate())
 })
 
 test_that("validate() catches string/integer mismatch that causes VDI export failure", {
@@ -553,7 +553,7 @@ test_that("validate() catches string/integer mismatch that causes VDI export fai
     set_variable_metadata('Number.of.animals', data_shape = 'categorical')
 
   # Now validation should pass
-  expect_true(households %>% validate())
+  expect_true(households %>% quiet() %>% validate())
 })
 
 test_that("validate() complains about binary variables with more than 2 unique values", {
@@ -564,7 +564,7 @@ test_that("validate() complains about binary variables with more than 2 unique v
     verbose()
 
   # Should validate cleanly
-  expect_true(participants %>% validate())
+  expect_true(participants %>% quiet() %>% validate())
 
   # Force Family.Role (3 values: Relative, Child, Parent) to binary
   participants <- participants %>%
@@ -583,7 +583,7 @@ test_that("validate() complains about binary variables with more than 2 unique v
     quiet() %>%
     set_variable_metadata('Family.Role', data_shape = 'categorical')
 
-  expect_true(participants %>% validate())
+  expect_true(participants %>% quiet() %>% validate())
 })
 
 test_that("validate() (EDA) complains about string values longer than 1000 characters", {

--- a/tests/testthat/test-Entity-validate.R
+++ b/tests/testthat/test-Entity-validate.R
@@ -586,3 +586,63 @@ test_that("validate() complains about binary variables with more than 2 unique v
   expect_true(participants %>% validate())
 })
 
+test_that("validate() (EDA) complains about string values longer than 1000 characters", {
+  file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+  households <- entity_from_file(file_path, name = 'household') %>%
+    quiet() %>%
+    set_variable_display_names_from_provider_labels()
+
+  # Should pass EDA validation out of the box
+  expect_true(households %>% quiet() %>% validate(profiles = c("baseline", "eda")))
+
+  # Inject a 1001-character value into Construction.material
+  households <- households %>%
+    quiet() %>%
+    modify_data(mutate(Construction.material = paste(rep("x", 1001), collapse = ""))) %>%
+    verbose()
+
+  # EDA validation should now fail
+  expect_warning(
+    expect_false(validate(households, profiles = c("baseline", "eda"))),
+    "Construction\\.material.+1001.+characters.+EDA backend limit is 1000"
+  )
+
+  # Baseline validation should still pass (this is an EDA-only constraint)
+  expect_true(households %>% quiet() %>% validate())
+
+  # Fix it by truncating
+  households <- households %>%
+    quiet() %>%
+    modify_data(mutate(Construction.material = substr(Construction.material, 1, 1000)))
+
+  expect_true(households %>% quiet() %>% validate(profiles = c("baseline", "eda")))
+})
+
+test_that("validate() (EDA) complains about string values containing newlines", {
+  file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+  households <- entity_from_file(file_path, name = 'household') %>%
+    quiet() %>%
+    set_variable_display_names_from_provider_labels()
+
+  # Inject a newline into Construction.material
+  households <- households %>%
+    quiet() %>%
+    modify_data(mutate(Construction.material = paste0(Construction.material, "\ninjected"))) %>%
+    verbose()
+
+  expect_warning(
+    expect_false(validate(households, profiles = c("baseline", "eda"))),
+    "Construction\\.material.+newline"
+  )
+
+  # Baseline should still pass
+  expect_true(households %>% quiet() %>% validate())
+
+  # Fix by replacing newlines with spaces
+  households <- households %>%
+    quiet() %>%
+    modify_data(mutate(Construction.material = gsub("\n|\r", " ", Construction.material)))
+
+  expect_true(households %>% quiet() %>% validate(profiles = c("baseline", "eda")))
+})
+

--- a/tests/testthat/test-entity_from_file.R
+++ b/tests/testthat/test-entity_from_file.R
@@ -55,7 +55,8 @@ test_that("entity_from_file detects column types correctly", {
   expect_equal(as.vector(result@variables$data_type), expected_types)
   
   # Check the data_shape has been inferred correctly
-  expected_shapes <- c(NA, "continuous", "categorical", "continuous", "categorical")
+  # "Owns property" (Yes/No) is detected as binary
+  expected_shapes <- c(NA, "continuous", "binary", "continuous", "categorical")
   expect_equal(as.vector(result@variables$data_shape), expected_shapes)
 })
 


### PR DESCRIPTION
## TRUE/FALSE and binary handling

**`R/utils.R` — `type_convert_quietly()`**: Added a check after `readr::type_convert()` — if the result is logical, the original character column is returned unchanged. This stops readr from silently converting `TRUE`/`FALSE`/`T`/`F` strings into R's logical type.

**`R/Entity-methods.R` — `infer_missing_data_shapes()`**: Added two-step boolean detection before the existing `case_when`. For string-type, non-multi-valued columns being inferred: (1) must have exactly 2 distinct non-NA values, (2) those values folded to lowercase must form one of `{true,false}`, `{t,f}`, `{yes,no}`, `{y,n}`. Matching columns get `data_shape = "binary"` instead of `"categorical"`.

**Tests updated**: `test-entity_from_file.R` expectation updated for "Owns property" (Yes/No) now correctly being `"binary"`, and the VDI export snapshot accepted to reflect the same change.

## newlines and 1000 char limit

**`R/entity-validators-eda-basic.R`** — two new validators:
- `validate_entity_string_value_length` — flags string variables with values >1000 chars; uses a two-stage check for multi-valued columns (fast `nchar` scan first, splitting only when raw cell >1000)
- `validate_entity_string_value_newlines` — flags string variables containing `\n`/`\r`; raw-cell check is sufficient (if no raw cell has a newline, no component can either)

**`R/validators.R`** — both registered in the `eda` profile

**`tests/testthat/test-Entity-validate.R`** — two new tests, each verifying the EDA profile fires on the bad data, baseline still passes (isolation), and the fix resolves the issue

