### PR TITLE
Add new upload_message layer to validation system

### DIFF
--- a/R/00_generics.R
+++ b/R/00_generics.R
@@ -24,9 +24,11 @@ setGeneric("verbose", function(object, ...) standardGeneric("verbose"))
 #' Validate Generic
 #'
 #' Defines the S4 generic for the validate function.
-#' 
+#'
 #' @param object The object to validate.
 #' @param profile Character vector of validation profiles to use. If NULL, uses global config.
+#' @param format Character. "full" (default) shows R-oriented messages with fix-it commands.
+#'   "upload" shows plain-language messages suitable for web upload users.
 #' @returns a Boolean indicating success or failure
 #' @export
-setGeneric("validate", function(object, profiles = NULL) standardGeneric("validate"))
+setGeneric("validate", function(object, profiles = NULL, format = "full") standardGeneric("validate"))

--- a/R/Entity-validate.R
+++ b/R/Entity-validate.R
@@ -8,7 +8,7 @@
 #' @param profile Character vector of validation profiles to use. If NULL, uses global config.
 #' @returns a Boolean indicating success or failure
 #' @export
-setMethod("validate", "Entity", function(object, profiles = NULL) {
+setMethod("validate", "Entity", function(object, profiles = NULL, format = "full") {
   entity <- object
   quiet <- entity@quiet
   
@@ -18,7 +18,7 @@ setMethod("validate", "Entity", function(object, profiles = NULL) {
   # Get validators for this profile and object type
   validators <- get_validators_for_profiles(profiles, "entity")
   
-  tools <- create_feedback_tools(quiet = quiet, success_message = "Entity is valid.")
+  tools <- create_feedback_tools(quiet = quiet, success_message = "Entity is valid.", format = format)
   add_feedback <- tools$add_feedback
   give_feedback <- tools$give_feedback
   get_is_valid <- tools$get_is_valid
@@ -33,20 +33,20 @@ setMethod("validate", "Entity", function(object, profiles = NULL) {
     if (!result$valid) {
       if (result$fatal %||% FALSE) {
         # Fatal error - stop validation immediately
-        give_feedback(fatal_message = result$message)
+        give_feedback(fatal_message = result$message, fatal_upload_message = result$upload_message)
         return(invisible(FALSE))
       } else if (validator_meta$stop_on_error %||% FALSE) {
         # Stop on error validator failed - stop validation immediately
-        give_feedback(fatal_message = result$message)
+        give_feedback(fatal_message = result$message, fatal_upload_message = result$upload_message)
         return(invisible(FALSE))
       } else {
         # Non-fatal warning - continue validation
-        add_feedback(result$message)
+        add_feedback(result$message, upload_message = result$upload_message)
       }
     } else if (is_truthy(result$message)) {
       # Advisory message - validation passed but there's informational feedback
       advisory <- result$advisory %||% FALSE
-      add_feedback(result$message, advisory = advisory)
+      add_feedback(result$message, advisory = advisory, upload_message = result$upload_message)
     }
   }
   

--- a/R/Study-validate.R
+++ b/R/Study-validate.R
@@ -7,7 +7,7 @@
 #' @param profile Character vector of validation profiles to use. If NULL, uses global config.
 #' @returns a Boolean indicating success or failure
 #' @export
-setMethod("validate", "Study", function(object, profiles = NULL) {
+setMethod("validate", "Study", function(object, profiles = NULL, format = "full") {
   study <- object
   quiet <- study@quiet
   
@@ -24,7 +24,8 @@ setMethod("validate", "Study", function(object, profiles = NULL) {
   
   tools <- create_feedback_tools(
     quiet = quiet,
-    success_message = glue("Study and its {length(entities)} {ifelse(length(entities) == 1, 'entity', 'entities')} are valid.")
+    success_message = glue("Study and its {length(entities)} {ifelse(length(entities) == 1, 'entity', 'entities')} are valid."),
+    format = format
   )
   add_feedback <- tools$add_feedback
   give_feedback <- tools$give_feedback
@@ -33,20 +34,21 @@ setMethod("validate", "Study", function(object, profiles = NULL) {
   # Validate all entities  
   entities %>% map(
     function(entity) {
-      is_valid <- entity %>% quiet() %>% validate(profiles = profiles)
+      is_valid <- entity %>% quiet() %>% validate(profiles = profiles, format = format)
       if (!is_valid) {
         entity_name <- get_entity_name(entity)
         add_feedback(
           glue(
             "The entity named '{entity_name}' is not valid.\nPlease run `{global_varname} %>% get_entity('{entity_name}') %>% verbose() %>% validate()` for more details."
-          )
+          ),
+          upload_message = glue("The '{entity_name}' data has validation issues. Please review the details above and correct your data file.")
         )
       }
     }
   )
   # early termination if any of the entities are invalid
   if (!get_is_valid()) {
-    give_feedback(fatal_message = "Error: one or more entities is invalid.")
+    give_feedback(fatal_message = "Error: one or more entities is invalid.", fatal_upload_message = "Your data has validation issues that must be fixed before it can be loaded.")
     return(invisible(FALSE))
   }
   
@@ -57,19 +59,19 @@ setMethod("validate", "Study", function(object, profiles = NULL) {
     if (!result$valid) {
       if (result$fatal %||% FALSE) {
         # Fatal error - stop validation immediately
-        give_feedback(fatal_message = result$message)
+        give_feedback(fatal_message = result$message, fatal_upload_message = result$upload_message)
         return(invisible(FALSE))
       } else if (validator_meta$stop_on_error %||% FALSE) {
         # Stop on error validator failed - stop validation immediately
-        give_feedback(fatal_message = result$message)
+        give_feedback(fatal_message = result$message, fatal_upload_message = result$upload_message)
         return(invisible(FALSE))
       } else {
         # Non-fatal warning - continue validation
-        add_feedback(result$message)
+        add_feedback(result$message, upload_message = result$upload_message)
       }
     } else if (is_truthy(result$message)) {
       # Advisory message - validation passed but there's informational feedback
-      add_feedback(result$message)
+      add_feedback(result$message, upload_message = result$upload_message)
     }
   }
   

--- a/R/entity-validators-eda-basic.R
+++ b/R/entity-validators-eda-basic.R
@@ -135,7 +135,14 @@ validate_entity_string_value_length <- function(entity) {
     sep = "\n"
   )
 
-  list(valid = FALSE, fatal = FALSE, message = message)
+  labels <- column_label(entity, too_long)
+  upload_message <- paste0(
+    "The following columns contain values longer than 1000 characters: ",
+    paste(labels, collapse = ", "),
+    ". Please shorten these values before uploading."
+  )
+
+  list(valid = FALSE, fatal = FALSE, message = message, upload_message = upload_message)
 }
 
 #' Validator: Check string variable values do not contain newline characters
@@ -178,5 +185,12 @@ validate_entity_string_value_newlines <- function(entity) {
     sep = "\n"
   )
 
-  list(valid = FALSE, fatal = FALSE, message = message)
+  labels <- column_label(entity, has_newlines)
+  upload_message <- paste0(
+    "The following columns contain line breaks, which are not supported: ",
+    paste(labels, collapse = ", "),
+    ". Please remove or replace all line breaks in these columns before uploading."
+  )
+
+  list(valid = FALSE, fatal = FALSE, message = message, upload_message = upload_message)
 }

--- a/R/feedback_tools.R
+++ b/R/feedback_tools.R
@@ -1,19 +1,29 @@
-create_feedback_tools <- function(quiet = FALSE, success_message = "Validation successful!") {
+create_feedback_tools <- function(quiet = FALSE, success_message = "Validation successful!", format = "full") {
   # Internal state, private to the closures
   is_valid <- TRUE
-  feedback <- character()
-  advisory_feedback <- character()
-  
-  add_feedback <- function(message, advisory = FALSE) {
-    if (advisory) {
-      advisory_feedback <<- c(advisory_feedback, message)
+  feedback <- list()
+  advisory_feedback <- list()
+
+  # Pick the appropriate message text based on format
+  pick_message <- function(entry) {
+    if (format == "upload" && !is.null(entry$upload_message) && nzchar(entry$upload_message)) {
+      entry$upload_message
     } else {
-      feedback <<- c(feedback, message)
+      entry$message
+    }
+  }
+
+  add_feedback <- function(message, advisory = FALSE, upload_message = NULL) {
+    entry <- list(message = message, upload_message = upload_message)
+    if (advisory) {
+      advisory_feedback <<- c(advisory_feedback, list(entry))
+    } else {
+      feedback <<- c(feedback, list(entry))
       is_valid <<- FALSE
     }
   }
-  
-  give_feedback <- function(fatal_message = NULL) {
+
+  give_feedback <- function(fatal_message = NULL, fatal_upload_message = NULL) {
     if (!quiet && length(feedback) > 0) {
       n <- length(feedback)
       header <- if (n == 1) {
@@ -21,7 +31,8 @@ create_feedback_tools <- function(quiet = FALSE, success_message = "Validation s
       } else {
         paste0("Validation issues found (", n, " issues):")
       }
-      numbered_feedback <- paste0("[", seq_along(feedback), "] ", feedback)
+      texts <- vapply(feedback, pick_message, character(1))
+      numbered_feedback <- paste0("[", seq_along(texts), "] ", texts)
       warning(header, "\n\n", paste(numbered_feedback, collapse = "\n\n"))
     }
     if (!quiet && length(advisory_feedback) > 0) {
@@ -31,23 +42,51 @@ create_feedback_tools <- function(quiet = FALSE, success_message = "Validation s
       } else {
         paste0("Advisory messages (", n_adv, " messages):")
       }
-      numbered_advisory <- paste0("[", seq_along(advisory_feedback), "] ", advisory_feedback)
+      adv_texts <- vapply(advisory_feedback, pick_message, character(1))
+      numbered_advisory <- paste0("[", seq_along(adv_texts), "] ", adv_texts)
       message(header, "\n\n", paste(numbered_advisory, collapse = "\n\n"))
     }
     if (is.character(fatal_message)) {
-      warning("Fatal issue encountered:\n", fatal_message, call. = FALSE)
+      fatal_text <- if (format == "upload" && !is.null(fatal_upload_message) && nzchar(fatal_upload_message)) {
+        fatal_upload_message
+      } else {
+        fatal_message
+      }
+      warning("Fatal issue encountered:\n", fatal_text, call. = FALSE)
     } else if (!quiet && length(feedback) == 0) {
       message(success_message)
     }
   }
-  
+
   # A getter to check validity.
   get_is_valid <- function() is_valid
-  
+
   # Return a list of the closures.
   list(
     add_feedback = add_feedback,
     give_feedback = give_feedback,
     get_is_valid = get_is_valid
   )
+}
+
+#' Get the original column label for a variable (for upload messages)
+#'
+#' Returns the first provider_label value for the variable, falling back
+#' to the variable name if provider_label is not set.
+#'
+#' @param entity An Entity object
+#' @param variable_name The internal variable name(s) — can be a character vector
+#' @return Character vector of original column labels
+#' @keywords internal
+column_label <- function(entity, variable_name) {
+  vapply(variable_name, function(vn) {
+    pl <- entity@variables %>%
+      filter(variable == vn) %>%
+      pull(provider_label)
+    if (length(pl) > 0 && length(pl[[1]]) > 0 && nzchar(pl[[1]][[1]])) {
+      pl[[1]][[1]]
+    } else {
+      vn
+    }
+  }, character(1), USE.NAMES = FALSE)
 }

--- a/tests/testthat/test-entity-validators-eda-basic.R
+++ b/tests/testthat/test-entity-validators-eda-basic.R
@@ -100,6 +100,29 @@ test_that("eda_display_name_not_null validator passes when categories have displ
   expect_true(households %>% quiet() %>% validate(profiles = c("baseline", "eda")))
 })
 
+# Tests for format = "upload" output
+
+test_that("format='upload' emits upload_message for string value length (no R code)", {
+  file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+
+  households <- entity_from_file(file_path, name = 'household') %>%
+    quiet() %>%
+    set_variable_metadata('Number.of.animals', display_name = 'Number of animals') %>%
+    set_variable_metadata('Owns.property', display_name = 'Owns property') %>%
+    set_variable_metadata('Enrollment.date', display_name = 'Enrollment date') %>%
+    set_variable_metadata('Construction.material', display_name = 'Construction material') %>%
+    # Inject a long string value
+    modify_data(mutate(Construction.material = paste0(Construction.material, strrep("x", 1001)))) %>%
+    verbose()
+
+  # Non-fatal warning should contain upload_message with original column name, no R code
+  expect_warning(
+    is_valid <- validate(households, profiles = c("baseline", "eda"), format = "upload"),
+    "longer than 1000 characters.*Construction material"
+  )
+  expect_false(is_valid)
+})
+
 test_that("eda_display_name_not_null validator fails when both variables and categories missing display_name", {
   file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
 

--- a/tests/testthat/test-feedback-tools.R
+++ b/tests/testthat/test-feedback-tools.R
@@ -1,0 +1,99 @@
+# Tests for feedback_tools.R — format-aware message selection
+
+test_that("format='full' emits message even when upload_message is present", {
+  tools <- create_feedback_tools(format = "full")
+  tools$add_feedback("R fix: use foo()", upload_message = "Please fix column 'foo'.")
+  expect_warning(
+    tools$give_feedback(),
+    "R fix: use foo()",
+    fixed = TRUE
+  )
+})
+
+test_that("format='upload' emits upload_message when present", {
+  tools <- create_feedback_tools(format = "upload")
+  tools$add_feedback("R fix: use foo()", upload_message = "Please fix column 'foo'.")
+  expect_warning(
+    tools$give_feedback(),
+    "Please fix column 'foo'.",
+    fixed = TRUE
+  )
+})
+
+test_that("format='upload' falls back to message when upload_message is NULL", {
+  tools <- create_feedback_tools(format = "upload")
+  tools$add_feedback("R fix: use foo()")
+  expect_warning(
+    tools$give_feedback(),
+    "R fix: use foo()",
+    fixed = TRUE
+  )
+})
+
+test_that("format='upload' falls back to message when upload_message is empty string", {
+  tools <- create_feedback_tools(format = "upload")
+  tools$add_feedback("R fix: use foo()", upload_message = "")
+  expect_warning(
+    tools$give_feedback(),
+    "R fix: use foo()",
+    fixed = TRUE
+  )
+})
+
+test_that("fatal path respects format='upload' with fatal_upload_message", {
+  tools <- create_feedback_tools(format = "upload")
+  expect_warning(
+    tools$give_feedback(
+      fatal_message = "R code: entity %>% fix()",
+      fatal_upload_message = "Your data could not be loaded."
+    ),
+    "Your data could not be loaded.",
+    fixed = TRUE
+  )
+})
+
+test_that("fatal path falls back to fatal_message when fatal_upload_message is NULL", {
+  tools <- create_feedback_tools(format = "upload")
+  expect_warning(
+    tools$give_feedback(fatal_message = "R code: entity %>% fix()"),
+    "R code: entity %>% fix()",
+    fixed = TRUE
+  )
+})
+
+test_that("advisory path respects format='upload'", {
+  tools <- create_feedback_tools(format = "upload")
+  tools$add_feedback("R advisory detail", advisory = TRUE, upload_message = "Please check column 'bar'.")
+  expect_message(
+    expect_message(
+      tools$give_feedback(),
+      "Please check column 'bar'.",
+      fixed = TRUE
+    ),
+    "Validation successful!",
+    fixed = TRUE
+  )
+})
+  
+test_that("default format is 'full'", {
+  tools <- create_feedback_tools()
+  tools$add_feedback("R fix message", upload_message = "Upload message")
+  expect_warning(
+    tools$give_feedback(),
+    "R fix message",
+    fixed = TRUE
+  )
+})
+
+test_that("get_is_valid returns FALSE after non-advisory feedback", {
+  tools <- create_feedback_tools()
+  expect_true(tools$get_is_valid())
+  tools$add_feedback("issue")
+  expect_false(tools$get_is_valid())
+})
+
+test_that("advisory feedback does not change is_valid", {
+  tools <- create_feedback_tools()
+  tools$add_feedback("note", advisory = TRUE)
+  expect_true(tools$get_is_valid())
+})


### PR DESCRIPTION
Both `validate` functions now have a `format = 'full'` (default) or `format = 'upload'` option.

The upload option aims to provide messaging and advice suitable for one-shot web-based file upload users.

The validator functions can now optionally return `upload_message` upon failure.