### PR TITLE
Fix trailing empty columns issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: study.wrangler
 Title: Wrangle (Tidy) Study Data
-Version: 1.0.36
+Version: 1.0.37
 Authors@R:
     c(person(given = "Bob",
            family = "MacCallum",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: study.wrangler
 Title: Wrangle (Tidy) Study Data
-Version: 1.0.35
+Version: 1.0.36
 Authors@R:
     c(person(given = "Bob",
            family = "MacCallum",

--- a/R/entity_from_file.R
+++ b/R/entity_from_file.R
@@ -82,6 +82,15 @@ entity_from_tibble <- function(data, preprocess_fn = NULL, skip_type_convert = F
     data <- preprocess_fn(data)
   }
 
+  # Silently remove ghost columns: empty/whitespace-only headers with all-NA values
+  ghost_col_indices <- which(
+    trimws(colnames(data)) == "" &
+    sapply(data, function(col) all(is.na(col)))
+  )
+  if (length(ghost_col_indices) > 0) {
+    data <- data[, -ghost_col_indices, drop = FALSE]
+  }
+
   provider_labels <- colnames(data) %>% map(list)
   clean_names <- make.names(colnames(data), unique = TRUE)
   colnames(data) <- clean_names

--- a/inst/extdata/toy_example/trailingEmptyColumns.tsv
+++ b/inst/extdata/toy_example/trailingEmptyColumns.tsv
@@ -1,0 +1,4 @@
+Household Id	Number of animals	Owns property	Enrollment date	Construction material			
+H001	4	Yes	2021-01-09	Concrete			
+H002	3	No	2021-02-28	Timber			
+H003	3	Yes	2021-03-13	Concrete			

--- a/tests/testthat/test-entity_from_file.R
+++ b/tests/testthat/test-entity_from_file.R
@@ -108,12 +108,48 @@ test_that("entity_from_file sets metadata from ... args", {
 })
 
 test_that("entity_from_file reports problems from read_tsv()", {
-  
+
   file_path <- system.file("extdata", "toy_example/brokenHouseholds.tsv", package = 'study.wrangler')
-  
+
   expect_error(
     result <- entity_from_file(file_path, name = "household"),
     "Issues were encountered while parsing the file.+5 columns.+6 columns"
   )
+})
+
+test_that("entity_from_file silently removes trailing empty columns", {
+  file_path <- system.file("extdata", "toy_example/trailingEmptyColumns.tsv", package = 'study.wrangler')
+
+  # Should be silent — no spurious duplicate column name warning
+  expect_silent(
+    result <- entity_from_file(file_path)
+  )
+
+  # Should produce the same columns as the clean version
+  households_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+  reference <- entity_from_file(households_path)
+  expect_equal(colnames(result@data), colnames(reference@data))
+  expect_equal(result@variables$variable, reference@variables$variable)
+})
+
+test_that("entity_from_tibble silently removes whitespace-header empty columns", {
+  ghost_data <- tibble::tibble(
+    `Household Id` = c("HH_1", "HH_2"),
+    `Number of animals` = c("3", "5"),
+    `   ` = c(NA_character_, NA_character_)
+  )
+  expect_silent(
+    result <- entity_from_tibble(ghost_data)
+  )
+  expect_equal(ncol(result@data), 2)
+  expect_equal(result@variables$variable, c("Household.Id", "Number.of.animals"))
+})
+
+test_that("entity_from_tibble keeps empty-header columns that have real data", {
+  # A column with empty header but real data is NOT a ghost column
+  real_data <- tibble::tibble(`Household Id` = c("HH_1", "HH_2"), x = c("value1", "value2"))
+  colnames(real_data)[2] <- ""
+  result <- entity_from_tibble(real_data)
+  expect_equal(ncol(result@data), 2)
 })
 


### PR DESCRIPTION
User-uploaded TSV/CSV files sometimes contain trailing empty columns (just tab delimiters with no header text and no data). `readr` with `name_repair='minimal'` reads these with empty string headers (`""`), which `make.names()` then converts to `X`, `X.1`, `X.2`, etc. This causes spurious "Duplicate column names detected" warnings and leaves completely empty columns in the entity, which subsequently fail validation with misleading "declared as string but contains logical values" errors.

The fix is to silently strip any (trailing or otherwise) empty (all-NA) columns from input data which also have empty (or all white-space) column headings.