### PR TITLE
Add geohash generation and display_type validation for geocoordinates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: study.wrangler
 Title: Wrangle (Tidy) Study Data
-Version: 1.0.38
+Version: 1.0.39
 Authors@R:
     c(person(given = "Bob",
            family = "MacCallum",

--- a/R/Entity-methods-eda.R
+++ b/R/Entity-methods-eda.R
@@ -137,10 +137,9 @@ function(entity) {
              USE.NAMES = FALSE, SIMPLIFY = TRUE)
     }
   ) %>% as_tibble()
-
-  entity <- entity %>%
-    modify_data(bind_cols(geohash_data)) %>%
-    sync_variable_metadata()
+  # Evaluate bind_cols eagerly here to avoid NSE scoping issues with modify_data's ... forwarding
+  entity <- initialize(entity, data = dplyr::bind_cols(entity@data, geohash_data))
+  entity <- entity %>% sync_variable_metadata()
 
   # Set metadata for each geohash column
   for (col_name in geohash_cols) {
@@ -149,6 +148,7 @@ function(entity) {
       set_variable_metadata(col_name,
         stable_id    = geoagg_ids[[col_name]],
         data_type    = factor('string'),
+        data_shape   = factor('categorical'),
         display_type = factor('geoaggregator'),
         display_name = glue("Geohash (precision {precision})"),
         hidden       = list('everywhere')

--- a/R/Entity-methods-eda.R
+++ b/R/Entity-methods-eda.R
@@ -111,11 +111,54 @@ function(entity) {
   lng_var <- lng_vars[1]
 
   entity <- entity %>%
-    set_variable_metadata(lat_var, stable_id = get_config()$export$eda$stable_ids$latitude, data_type = factor('number')) %>%
-    set_variable_metadata(lng_var, stable_id = get_config()$export$eda$stable_ids$longitude, data_type = factor('longitude'))
+    set_variable_metadata(lat_var,
+      stable_id  = get_config()$export$eda$stable_ids$latitude,
+      data_type  = factor('number'),
+      display_type = factor('latitude')
+    ) %>%
+    set_variable_metadata(lng_var,
+      stable_id  = get_config()$export$eda$stable_ids$longitude,
+      data_type  = factor('longitude'),
+      display_type = factor('longitude')
+    )
+
+  # Generate six geohash columns (precision 1–6) from the numeric lat/lng data
+  lat_data <- as.numeric(entity@data[[lat_var]])
+  lng_data <- as.numeric(entity@data[[lng_var]])
+
+  geoagg_ids   <- get_config()$export$eda$stable_ids$geoaggregator
+  geohash_cols <- names(geoagg_ids)  # "geohash_1" … "geohash_6"
+
+  # Add all six geohash columns to the data in one mutate call
+  geohash_data <- purrr::imap(
+    setNames(seq_along(geohash_cols), geohash_cols),
+    function(precision, col_name) {
+      mapply(encode_geohash, lat_data, lng_data, precision,
+             USE.NAMES = FALSE, SIMPLIFY = TRUE)
+    }
+  ) %>% as_tibble()
+
+  entity <- entity %>%
+    modify_data(bind_cols(geohash_data)) %>%
+    sync_variable_metadata()
+
+  # Set metadata for each geohash column
+  for (col_name in geohash_cols) {
+    precision <- as.integer(sub("geohash_", "", col_name))
+    entity <- entity %>%
+      set_variable_metadata(col_name,
+        stable_id    = geoagg_ids[[col_name]],
+        data_type    = factor('string'),
+        display_type = factor('geoaggregator'),
+        display_name = glue("Geohash (precision {precision})")
+      )
+  }
 
   if (!entity@quiet) {
-    message(glue("Set geographic metadata for latitude variable '{lat_var}' and longitude variable '{lng_var}'"))
+    message(glue(
+      "Set geographic metadata for latitude variable '{lat_var}' and longitude variable '{lng_var}', ",
+      "and generated geohash columns: {paste(geohash_cols, collapse = ', ')}"
+    ))
   }
 
   return(entity)

--- a/R/Entity-methods-eda.R
+++ b/R/Entity-methods-eda.R
@@ -150,7 +150,8 @@ function(entity) {
         stable_id    = geoagg_ids[[col_name]],
         data_type    = factor('string'),
         display_type = factor('geoaggregator'),
-        display_name = glue("Geohash (precision {precision})")
+        display_name = glue("Geohash (precision {precision})"),
+        hidden       = list('everywhere')
       )
   }
 

--- a/R/config.R
+++ b/R/config.R
@@ -20,7 +20,15 @@ NULL
     eda = list(
       stable_ids = list(
         latitude = 'OBI_0001620',
-        longitude = 'OBI_0001621'
+        longitude = 'OBI_0001621',
+        geoaggregator = list(
+          geohash_1 = 'EUPATH_0043203',
+          geohash_2 = 'EUPATH_0043204',
+          geohash_3 = 'EUPATH_0043205',
+          geohash_4 = 'EUPATH_0043206',
+          geohash_5 = 'EUPATH_0043207',
+          geohash_6 = 'EUPATH_0043208'
+        )
       )
     )
   )

--- a/R/entity-validators-eda-geocoords.R
+++ b/R/entity-validators-eda-geocoords.R
@@ -102,6 +102,9 @@ validate_geocoordinate_variables <- function(entity) {
   if (is.na(lat_metadata$data_type) || lat_metadata$data_type != 'number') {
     lat_issues <- c(lat_issues, paste0("Latitude variable '", lat_var, "' must have data_type = 'number'"))
   }
+  if (is.na(lat_metadata$display_type) || lat_metadata$display_type != 'latitude') {
+    lat_issues <- c(lat_issues, paste0("Latitude variable '", lat_var, "' must have display_type = 'latitude'"))
+  }
 
   # Validate the longitude variable
   lng_var <- lng_vars[1]
@@ -115,9 +118,24 @@ validate_geocoordinate_variables <- function(entity) {
   if (is.na(lng_metadata$data_type) || lng_metadata$data_type != 'longitude') {
     lng_issues <- c(lng_issues, paste0("Longitude variable '", lng_var, "' must have data_type = 'longitude'"))
   }
-  
+  if (is.na(lng_metadata$display_type) || lng_metadata$display_type != 'longitude') {
+    lng_issues <- c(lng_issues, paste0("Longitude variable '", lng_var, "' must have display_type = 'longitude'"))
+  }
+
+  # Validate that geoaggregator variables are present (front-end requirement)
+  expected_geoagg_ids <- unlist(get_config()$export$eda$stable_ids$geoaggregator, use.names = FALSE)
+  geoagg_vars <- variables %>%
+    filter(!is.na(display_type), display_type == 'geoaggregator') %>%
+    pull(stable_id)
+
+  geoagg_issues <- c()
+  if (length(intersect(geoagg_vars, expected_geoagg_ids)) == 0) {
+    geoagg_issues <- c(geoagg_issues,
+      "No geoaggregator variables found. Geohash variables with display_type = 'geoaggregator' are required alongside latitude/longitude variables.")
+  }
+
   # Combine all issues
-  all_issues <- c(lat_issues, lng_issues)
+  all_issues <- c(lat_issues, lng_issues, geoagg_issues)
 
   if (length(all_issues) > 0) {
     # Get global variable name for fix-it suggestions
@@ -126,7 +144,7 @@ validate_geocoordinate_variables <- function(entity) {
     message <- paste(
       paste(all_issues, collapse = "\n"),
       "",
-      "To automatically set the correct metadata for geocoordinate variables, use:",
+      "To automatically set the correct metadata and generate geohash variables, use:",
       paste0("    ", global_varname, " <- ", global_varname, " %>% infer_geo_variables_for_eda()"),
       sep = "\n"
     )
@@ -137,7 +155,7 @@ validate_geocoordinate_variables <- function(entity) {
       message = message
     ))
   }
-  
+
   # All validations passed
   list(valid = TRUE)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -720,3 +720,52 @@ write_pretty_yaml <- function(data, file) {
     str_replace_all("(\n\\w+:(?: \\[\\])?\n)", "\n\\1") %>%
     writeLines(file)
 }
+
+#' Encode a latitude/longitude coordinate pair as a geohash string
+#'
+#' Faithful port of the Perl `encodeGeohash` function from VEuPathDB/ApiCommonData.
+#' The algorithm starts with longitude (even bits), alternates with latitude (odd bits),
+#' and encodes every 5 bits into one character of the base-32 alphabet
+#' `0123456789bcdefghjkmnpqrstuvwxyz`.
+#'
+#' @param latitude  Numeric latitude  (-90 to 90).  NA returns NA.
+#' @param longitude Numeric longitude (-180 to 180). NA returns NA.
+#' @param precision Integer number of geohash characters (1–12 are typical).
+#' @return A character string of length `precision`, or `NA_character_` when
+#'   either coordinate is NA.
+#' @keywords internal
+encode_geohash <- function(latitude, longitude, precision) {
+  if (is.na(latitude) || is.na(longitude)) return(NA_character_)
+
+  geo32 <- c('0','1','2','3','4','5','6','7','8','9',
+             'b','c','d','e','f','g','h','j','k','m',
+             'n','p','q','r','s','t','u','v','w','x','y','z')
+
+  coord     <- c(as.numeric(latitude), as.numeric(longitude))
+  range_lat <- c(-90,  90)
+  range_lng <- c(-180, 180)
+  which_idx <- 2L   # start with longitude (Perl: $which = 1, 0-indexed)
+  n_bits    <- precision * 5L
+  bits      <- integer(n_bits)
+
+  for (k in seq_len(n_bits)) {
+    rng <- if (which_idx == 1L) range_lat else range_lng
+    mid <- (rng[1] + rng[2]) / 2
+    if (coord[which_idx] <= mid) {
+      bits[k] <- 0L
+      if (which_idx == 1L) range_lat[2] <- mid else range_lng[2] <- mid
+    } else {
+      bits[k] <- 1L
+      if (which_idx == 1L) range_lat[1] <- mid else range_lng[1] <- mid
+    }
+    which_idx <- if (which_idx == 2L) 1L else 2L
+  }
+
+  enc <- character(precision)
+  for (i in seq_len(precision)) {
+    s   <- (i - 1L) * 5L + 1L
+    idx <- sum(bits[s:(s + 4L)] * c(16L, 8L, 4L, 2L, 1L)) + 1L
+    enc[i] <- geo32[idx]
+  }
+  paste(enc, collapse = '')
+}

--- a/tests/testthat/test-entity-validators-eda-geocoords.R
+++ b/tests/testthat/test-entity-validators-eda-geocoords.R
@@ -515,4 +515,3 @@ test_that("geocoordinate validator fails when no geoaggregator variables are pre
   )
   expect_false(is_valid)
 })
-})

--- a/tests/testthat/test-entity-validators-eda-geocoords.R
+++ b/tests/testthat/test-entity-validators-eda-geocoords.R
@@ -422,6 +422,7 @@ test_that("infer_geo_variables_for_eda generates six geohash columns with correc
     expect_equal(as.character(row$display_type), 'geoaggregator', info = col_name)
     expect_equal(row$stable_id, expected_ids[[col_name]], info = col_name)
     expect_equal(as.character(row$data_type), 'string', info = col_name)
+    expect_equal(as.character(unlist(row$hidden)), 'everywhere', info = col_name)
   }
 
   # Data should also contain the six columns

--- a/tests/testthat/test-entity-validators-eda-geocoords.R
+++ b/tests/testthat/test-entity-validators-eda-geocoords.R
@@ -251,14 +251,10 @@ test_that("geocoordinate validator passes when both variables have correct metad
     ))
   }
 
-  expected_lat_stable_id <- get_config()$export$eda$stable_ids$latitude
-  expected_lng_stable_id <- get_config()$export$eda$stable_ids$longitude
-
   households <- entity_from_file(file_path, name = 'household', preprocess_fn = add_geo_coords) %>%
     quiet() %>%
-    set_variable_metadata('latitude', stable_id = expected_lat_stable_id, data_type = 'number') %>%
-    set_variable_metadata('longitude', stable_id = expected_lng_stable_id, data_type = 'longitude') %>%
     set_variable_display_names_from_provider_labels() %>%
+    infer_geo_variables_for_eda() %>%
     verbose()
 
   # Should pass validation, include baseline checks too
@@ -267,7 +263,7 @@ test_that("geocoordinate validator passes when both variables have correct metad
 
 test_that("geocoordinate validator detects partial matches in variable names", {
   file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
-  
+
   # Add columns with partial name matches (as character since preprocess_fn gets character data)
   add_partial_names <- function(data) {
     return(data %>% mutate(
@@ -275,17 +271,13 @@ test_that("geocoordinate validator detects partial matches in variable names", {
       original_long = c("-74.0", "-73.0", "-72.0")
     ))
   }
-  
-  expected_lat_stable_id <- get_config()$export$eda$stable_ids$latitude
-  expected_lng_stable_id <- get_config()$export$eda$stable_ids$longitude
-  
+
   households <- entity_from_file(file_path, name = 'household', preprocess_fn = add_partial_names) %>%
     quiet() %>%
-    set_variable_metadata('original_lat', stable_id = expected_lat_stable_id, data_type = 'number') %>%
-    set_variable_metadata('original_long', stable_id = expected_lng_stable_id, data_type = 'longitude') %>%
     set_variable_display_names_from_provider_labels() %>%
+    infer_geo_variables_for_eda() %>%
     verbose()
-  
+
   # Should pass validation (partial matches should work)
   expect_true(households %>% quiet() %>% validate(profiles = c("baseline", "eda")))
 })
@@ -364,7 +356,7 @@ test_that("geocoordinate validator provides remedial guidance and fix works", {
   # Should fail validation with remedial guidance (uses 'entity' as fallback name in test context)
   expect_warning(
     is_valid <- validate(households, profiles = c("baseline", "eda")),
-    "To automatically set the correct metadata for geocoordinate variables, use:.*entity.*%>%.*infer_geo_variables_for_eda\\(\\)"
+    "To automatically set the correct metadata and generate geohash variables, use:.*entity.*%>%.*infer_geo_variables_for_eda\\(\\)"
   )
   expect_false(is_valid)
 
@@ -373,4 +365,154 @@ test_that("geocoordinate validator provides remedial guidance and fix works", {
 
   # Should now pass validation
   expect_true(households %>% validate(profiles = c("baseline", "eda")))
+})
+
+# ── encode_geohash unit tests ────────────────────────────────────────────────
+
+test_that("encode_geohash produces correct output for known coordinates", {
+  # (40.7, -74.0) is the New York City area; well-known geohash prefix "dr"
+  expect_equal(encode_geohash(40.7, -74.0, 1), "d")
+  expect_equal(encode_geohash(40.7, -74.0, 2), "dr")
+})
+
+test_that("encode_geohash returns NA for NA coordinates", {
+  expect_equal(encode_geohash(NA, -74.0, 1), NA_character_)
+  expect_equal(encode_geohash(40.7, NA, 1), NA_character_)
+})
+
+# ── infer_geo_variables_for_eda geohash generation tests ────────────────────
+
+test_that("infer_geo_variables_for_eda sets display_type for lat and lng variables", {
+  file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+  add_geo_coords <- function(data) {
+    data %>% mutate(
+      latitude  = c("40.7", "41.0", "42.0"),
+      longitude = c("-74.0", "-73.0", "-72.0")
+    )
+  }
+
+  households <- entity_from_file(file_path, name = 'household', preprocess_fn = add_geo_coords) %>%
+    quiet() %>%
+    infer_geo_variables_for_eda()
+
+  vars <- households@variables
+  expect_equal(as.character(vars %>% filter(variable == 'latitude')  %>% pull(display_type)), 'latitude')
+  expect_equal(as.character(vars %>% filter(variable == 'longitude') %>% pull(display_type)), 'longitude')
+})
+
+test_that("infer_geo_variables_for_eda generates six geohash columns with correct metadata", {
+  file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+  add_geo_coords <- function(data) {
+    data %>% mutate(
+      latitude  = c("40.7", "41.0", "42.0"),
+      longitude = c("-74.0", "-73.0", "-72.0")
+    )
+  }
+
+  households <- entity_from_file(file_path, name = 'household', preprocess_fn = add_geo_coords) %>%
+    quiet() %>%
+    infer_geo_variables_for_eda()
+
+  expected_ids <- get_config()$export$eda$stable_ids$geoaggregator
+  vars <- households@variables
+
+  for (col_name in names(expected_ids)) {
+    row <- vars %>% filter(variable == col_name)
+    expect_equal(nrow(row), 1, info = paste("missing metadata row for", col_name))
+    expect_equal(as.character(row$display_type), 'geoaggregator', info = col_name)
+    expect_equal(row$stable_id, expected_ids[[col_name]], info = col_name)
+    expect_equal(as.character(row$data_type), 'string', info = col_name)
+  }
+
+  # Data should also contain the six columns
+  for (col_name in names(expected_ids)) {
+    expect_true(col_name %in% colnames(households@data), info = col_name)
+    expect_type(households@data[[col_name]], "character")
+  }
+
+  # Verify geohash values for the first row (lat=40.7, lng=-74.0)
+  expect_equal(households@data[["geohash_1"]][1], "d")
+  expect_equal(households@data[["geohash_2"]][1], "dr")
+})
+
+# ── Validator display_type tests ─────────────────────────────────────────────
+
+test_that("geocoordinate validator fails when latitude variable has wrong display_type", {
+  file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+  add_geo_coords <- function(data) {
+    data %>% mutate(
+      latitude  = c("40.7", "41.0", "42.0"),
+      longitude = c("-74.0", "-73.0", "-72.0")
+    )
+  }
+
+  expected_lat_stable_id <- get_config()$export$eda$stable_ids$latitude
+  expected_lng_stable_id <- get_config()$export$eda$stable_ids$longitude
+
+  households <- entity_from_file(file_path, name = 'household', preprocess_fn = add_geo_coords) %>%
+    quiet() %>%
+    set_variable_metadata('latitude',  stable_id = expected_lat_stable_id, data_type = 'number',    display_type = 'default') %>%
+    set_variable_metadata('longitude', stable_id = expected_lng_stable_id, data_type = 'longitude', display_type = 'longitude') %>%
+    set_variable_display_names_from_provider_labels() %>%
+    verbose()
+
+  expect_warning(
+    is_valid <- validate(households, profiles = c("baseline", "eda")),
+    "Latitude variable 'latitude' must have display_type = 'latitude'"
+  )
+  expect_false(is_valid)
+})
+
+test_that("geocoordinate validator fails when longitude variable has wrong display_type", {
+  file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+  add_geo_coords <- function(data) {
+    data %>% mutate(
+      latitude  = c("40.7", "41.0", "42.0"),
+      longitude = c("-74.0", "-73.0", "-72.0")
+    )
+  }
+
+  expected_lat_stable_id <- get_config()$export$eda$stable_ids$latitude
+  expected_lng_stable_id <- get_config()$export$eda$stable_ids$longitude
+
+  households <- entity_from_file(file_path, name = 'household', preprocess_fn = add_geo_coords) %>%
+    quiet() %>%
+    set_variable_metadata('latitude',  stable_id = expected_lat_stable_id, data_type = 'number',    display_type = 'latitude') %>%
+    set_variable_metadata('longitude', stable_id = expected_lng_stable_id, data_type = 'longitude', display_type = 'default') %>%
+    set_variable_display_names_from_provider_labels() %>%
+    verbose()
+
+  expect_warning(
+    is_valid <- validate(households, profiles = c("baseline", "eda")),
+    "Longitude variable 'longitude' must have display_type = 'longitude'"
+  )
+  expect_false(is_valid)
+})
+
+test_that("geocoordinate validator fails when no geoaggregator variables are present", {
+  file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+  add_geo_coords <- function(data) {
+    data %>% mutate(
+      latitude  = c("40.7", "41.0", "42.0"),
+      longitude = c("-74.0", "-73.0", "-72.0")
+    )
+  }
+
+  expected_lat_stable_id <- get_config()$export$eda$stable_ids$latitude
+  expected_lng_stable_id <- get_config()$export$eda$stable_ids$longitude
+
+  # Set correct lat/lng metadata including display_type, but no geohash/geoaggregator variables
+  households <- entity_from_file(file_path, name = 'household', preprocess_fn = add_geo_coords) %>%
+    quiet() %>%
+    set_variable_metadata('latitude',  stable_id = expected_lat_stable_id, data_type = 'number',    display_type = 'latitude') %>%
+    set_variable_metadata('longitude', stable_id = expected_lng_stable_id, data_type = 'longitude', display_type = 'longitude') %>%
+    set_variable_display_names_from_provider_labels() %>%
+    verbose()
+
+  expect_warning(
+    is_valid <- validate(households, profiles = c("baseline", "eda")),
+    "No geoaggregator variables found"
+  )
+  expect_false(is_valid)
+})
 })


### PR DESCRIPTION
## Summary
This PR enhances the geographic coordinate handling in the EDA export by introducing automatic geohash generation and adding display_type validation for latitude/longitude variables.

## Key Changes

- **Geohash Generation**: Implemented `encode_geohash()` utility function that converts latitude/longitude pairs into geohash strings using a faithful port of the VEuPathDB algorithm. Supports precision levels 1-12.

- **Enhanced `infer_geo_variables_for_eda()`**: Extended the function to:
  - Set `display_type = 'latitude'` and `display_type = 'longitude'` for coordinate variables
  - Automatically generate six geohash columns (precision 1-6) from numeric lat/lng data
  - Add proper metadata for geohash columns with `display_type = 'geoaggregator'`

- **Validator Improvements**: Updated `validate_geocoordinate_variables()` to:
  - Validate that latitude and longitude variables have correct `display_type` values
  - Require presence of geoaggregator variables (geohash columns) alongside coordinates
  - Updated remedial guidance message to mention geohash generation

- **Configuration**: Added stable IDs for six geohash columns (EUPATH_0043203 through EUPATH_0043208) to the EDA export configuration.

- **Test Coverage**: Added comprehensive tests for:
  - Geohash encoding with known coordinates (NYC area)
  - NA handling in geohash generation
  - Display type validation for lat/lng variables
  - Geoaggregator variable presence validation
  - Simplified existing tests to use `infer_geo_variables_for_eda()` instead of manual metadata setting

## Implementation Details

The geohash algorithm alternates between longitude (even bits) and latitude (odd bits), encoding every 5 bits into base-32 characters. The implementation maintains state across iterations to progressively narrow the coordinate ranges and generate the binary representation.

https://claude.ai/code/session_01H3j52GjWTRKYy7huJTjbSp