### PR TITLE
Drop empty columns with messaging and validate lat/long values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: study.wrangler
 Title: Wrangle (Tidy) Study Data
-Version: 1.0.40
+Version: 1.0.41
 Authors@R:
     c(person(given = "Bob",
            family = "MacCallum",

--- a/R/entity-validators-eda-basic.R
+++ b/R/entity-validators-eda-basic.R
@@ -91,6 +91,7 @@ validate_entity_string_value_length <- function(entity) {
 
   exceeds_limit <- function(col_name, is_mv, delim) {
     vals <- data[[col_name]]
+    if (all(is.na(vals))) return(FALSE)
     raw_lengths <- nchar(vals)
     if (max(raw_lengths, na.rm = TRUE) <= 1000) return(FALSE)
 

--- a/R/entity-validators-eda-geocoords.R
+++ b/R/entity-validators-eda-geocoords.R
@@ -156,6 +156,51 @@ validate_geocoordinate_variables <- function(entity) {
     ))
   }
 
+  # Validate actual coordinate values
+  lat_values <- suppressWarnings(as.numeric(entity@data[[lat_var]]))
+  lng_values <- suppressWarnings(as.numeric(entity@data[[lng_var]]))
+
+  value_issues <- c()
+
+  # Check for partial pairs (one NA, the other not)
+  partial_pairs <- is.na(lat_values) != is.na(lng_values)
+  if (any(partial_pairs)) {
+    value_issues <- c(value_issues, paste0(
+      sum(partial_pairs), " row(s) have only one coordinate value (partial lat/lng pair). ",
+      "Both latitude and longitude must be present or both must be absent."
+    ))
+  }
+
+  # Check latitude range [-90, 90]
+  non_na_lat <- lat_values[!is.na(lat_values)]
+  if (length(non_na_lat) > 0 && any(non_na_lat < -90 | non_na_lat > 90)) {
+    value_issues <- c(value_issues, paste0(
+      sum(non_na_lat < -90 | non_na_lat > 90),
+      " latitude value(s) are outside the WGS-84 range [-90, 90]."
+    ))
+  }
+
+  # Check longitude range [-180, 180]
+  non_na_lng <- lng_values[!is.na(lng_values)]
+  if (length(non_na_lng) > 0 && any(non_na_lng < -180 | non_na_lng > 180)) {
+    value_issues <- c(value_issues, paste0(
+      sum(non_na_lng < -180 | non_na_lng > 180),
+      " longitude value(s) are outside the WGS-84 range [-180, 180]."
+    ))
+  }
+
+  if (length(value_issues) > 0) {
+    return(list(
+      valid = FALSE,
+      fatal = TRUE,
+      message = paste(
+        paste(value_issues, collapse = "\n"),
+        "Coordinate data must use WGS-84 decimal degrees.",
+        sep = "\n"
+      )
+    ))
+  }
+
   # All validations passed
   list(valid = TRUE)
 }

--- a/R/entity_from_file.R
+++ b/R/entity_from_file.R
@@ -91,6 +91,22 @@ entity_from_tibble <- function(data, preprocess_fn = NULL, skip_type_convert = F
     data <- data[, -ghost_col_indices, drop = FALSE]
   }
 
+  # Drop named columns where every value is NA or blank, and inform the user
+  empty_data_indices <- which(
+    sapply(data, function(col) all(is.na(col) | trimws(as.character(col)) == ""))
+  )
+  if (length(empty_data_indices) > 0) {
+    empty_col_names <- colnames(data)[empty_data_indices]
+    if (!isTRUE(metadata$quiet)) {
+      message(
+        "Dropped ", length(empty_data_indices),
+        " empty column(s) (all values missing or blank): ",
+        paste(empty_col_names, collapse = ", ")
+      )
+    }
+    data <- data[, -empty_data_indices, drop = FALSE]
+  }
+
   provider_labels <- colnames(data) %>% map(list)
   clean_names <- make.names(colnames(data), unique = TRUE)
   colnames(data) <- clean_names

--- a/tests/testthat/test-entity-validators-eda-geocoords.R
+++ b/tests/testthat/test-entity-validators-eda-geocoords.R
@@ -490,6 +490,93 @@ test_that("geocoordinate validator fails when longitude variable has wrong displ
   expect_false(is_valid)
 })
 
+test_that("geocoordinate validator is fatal for latitude values outside [-90, 90]", {
+  file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+  add_bad_lat <- function(data) {
+    data %>% mutate(
+      latitude  = c("91.0", "41.0", "42.0"),
+      longitude = c("-74.0", "-73.0", "-72.0")
+    )
+  }
+  households <- entity_from_file(file_path, name = 'household', preprocess_fn = add_bad_lat) %>%
+    quiet() %>% infer_geo_variables_for_eda() %>% verbose()
+
+  expect_warning(
+    is_valid <- validate(households, profiles = c("baseline", "eda")),
+    "1 latitude value\\(s\\) are outside the WGS-84 range"
+  )
+  expect_false(is_valid)
+})
+
+test_that("geocoordinate validator is fatal for longitude values outside [-180, 180]", {
+  file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+  add_bad_lng <- function(data) {
+    data %>% mutate(
+      latitude  = c("40.7", "41.0", "42.0"),
+      longitude = c("-181.0", "-73.0", "-72.0")
+    )
+  }
+  households <- entity_from_file(file_path, name = 'household', preprocess_fn = add_bad_lng) %>%
+    quiet() %>% infer_geo_variables_for_eda() %>% verbose()
+
+  expect_warning(
+    is_valid <- validate(households, profiles = c("baseline", "eda")),
+    "1 longitude value\\(s\\) are outside the WGS-84 range"
+  )
+  expect_false(is_valid)
+})
+
+test_that("geocoordinate validator is fatal for partial lat/lng pairs", {
+  file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+  add_partial <- function(data) {
+    data %>% mutate(
+      latitude  = c("40.7", NA, "42.0"),
+      longitude = c("-74.0", "-73.0", NA)
+    )
+  }
+  households <- entity_from_file(file_path, name = 'household', preprocess_fn = add_partial) %>%
+    quiet() %>% infer_geo_variables_for_eda() %>% verbose()
+
+  expect_warning(
+    is_valid <- validate(households, profiles = c("baseline", "eda")),
+    "2 row\\(s\\) have only one coordinate value"
+  )
+  expect_false(is_valid)
+})
+
+test_that("geocoordinate validator reports multiple value issues together", {
+  file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+  add_multiple_issues <- function(data) {
+    data %>% mutate(
+      latitude  = c("91.0", NA, "42.0"),
+      longitude = c("-181.0", "-73.0", NA)
+    )
+  }
+  households <- entity_from_file(file_path, name = 'household', preprocess_fn = add_multiple_issues) %>%
+    quiet() %>% set_variable_display_names_from_provider_labels() %>% infer_geo_variables_for_eda() %>% verbose()
+
+  # Both the partial-pair issue and the range issue must appear in the same message
+  expect_warning(
+    is_valid <- validate(households, profiles = c("baseline", "eda")),
+    "partial lat/lng pair.*WGS-84 range"
+  )
+  expect_false(is_valid)
+})
+
+test_that("geocoordinate validator accepts rows where both lat and lng are NA", {
+  file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+  add_some_na <- function(data) {
+    data %>% mutate(
+      latitude  = c("40.7", NA, "42.0"),
+      longitude = c("-74.0", NA, "-72.0")
+    )
+  }
+  households <- entity_from_file(file_path, name = 'household', preprocess_fn = add_some_na) %>%
+    quiet() %>% set_variable_display_names_from_provider_labels() %>% infer_geo_variables_for_eda() %>% verbose()
+
+  expect_true(households %>% quiet() %>% validate(profiles = c("baseline", "eda")))
+})
+
 test_that("geocoordinate validator fails when no geoaggregator variables are present", {
   file_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
   add_geo_coords <- function(data) {

--- a/tests/testthat/test-entity_from_file.R
+++ b/tests/testthat/test-entity_from_file.R
@@ -153,3 +153,51 @@ test_that("entity_from_tibble keeps empty-header columns that have real data", {
   expect_equal(ncol(result@data), 2)
 })
 
+test_that("entity_from_tibble drops all-NA named columns with a message", {
+  data <- tibble::tibble(
+    id    = c("A", "B", "C"),
+    value = c("1", "2", "3"),
+    empty = c(NA_character_, NA_character_, NA_character_)
+  )
+  expect_message(
+    result <- entity_from_tibble(data),
+    "Dropped 1 empty column\\(s\\).*empty"
+  )
+  expect_equal(ncol(result@data), 2)
+  expect_equal(result@variables$variable, c("id", "value"))
+})
+
+test_that("entity_from_tibble drops all-blank-string named columns with a message", {
+  data <- tibble::tibble(
+    id    = c("A", "B"),
+    blank = c("", "  ")
+  )
+  expect_message(
+    result <- entity_from_tibble(data),
+    "Dropped 1 empty column\\(s\\).*blank"
+  )
+  expect_equal(ncol(result@data), 1)
+})
+
+test_that("entity_from_tibble suppresses empty-column message when quiet = TRUE", {
+  data <- tibble::tibble(
+    id    = c("A", "B"),
+    empty = c(NA_character_, NA_character_)
+  )
+  expect_silent(
+    result <- entity_from_tibble(data, quiet = TRUE)
+  )
+  expect_equal(ncol(result@data), 1)
+})
+
+test_that("entity_from_tibble keeps columns that have at least one non-empty value", {
+  data <- tibble::tibble(
+    id      = c("A", "B", "C"),
+    partial = c("x", NA, NA)
+  )
+  expect_silent(
+    result <- entity_from_tibble(data)
+  )
+  expect_equal(ncol(result@data), 2)
+})
+


### PR DESCRIPTION
All-empty columns cause all kinds of problems, so we've decided to skip them at the `entity_from_file()` stage. (Actually it's implemented in `entity_from_tibble()` which is called from `entity_from_file()` and friends.

Also we should have been validating the **values** of the lat/long variables. i.e. lat -90 to +90, long -180 to +180. This is done after the variable metadata validation, and is fatal.

---

Here's a summary of everything that changed:

**`R/entity_from_file.R`** — `entity_from_tibble` now drops named columns where every value is NA or blank after `preprocess_fn` runs, emitting a `message()` (suppressed when `quiet = TRUE`).

**`R/entity-validators-eda-basic.R`** — `exceeds_limit` short-circuits on all-NA columns before calling `max()`, eliminating the "no non-missing arguments to max" warnings.

**`R/entity-validators-eda-geocoords.R`** — After all metadata checks pass, value validation runs: partial pairs and out-of-range values both return `fatal = TRUE`.

**`vdi-plugin-wrangler/lib/R/wrangle-isasimple.R`** — `entity_from_file` called with `quiet = TRUE`, which propagates through the entity and suppresses all informational messages in the upload context.
