### PR TITLE
Sanitize newline, tab and backtick characters from VDI *.cache outputs

### DIFF
--- a/R/Study-export-VDI.R
+++ b/R/Study-export-VDI.R
@@ -63,7 +63,7 @@ setMethod("export_to_vdi", "Study", function(object, output_directory) {
   entitytypegraph_cache <- export_data$entitytypegraph_cache %>% bind_rows()
 
   write_tsv(
-    entitytypegraph_cache,
+    entitytypegraph_cache %>% sanitize_for_cache(),
     file = file.path(output_directory, "entitytypegraph.cache"),
     col_names = FALSE,
     na = '',
@@ -192,7 +192,7 @@ export_ancestors_to_vdi <- function(entities, output_directory, install_json, st
   # Output the data
   tablename <- glue("ancestors_{study %>% get_study_abbreviation()}_{entity_abbreviation}")
   filename <- glue("{tablename}.cache")
-  write_tsv(ancestors, file.path(output_directory, filename), col_names = FALSE)
+  write_tsv(ancestors %>% sanitize_for_cache(), file.path(output_directory, filename), col_names = FALSE)
   
   # Create the table definition JSON
   
@@ -298,7 +298,7 @@ export_attributes_to_vdi <- function(entities, output_directory, install_json, s
   filename <- glue("{tablename}.cache")
   # `escape = 'none'` prevents doubling of double-quotes
   write_tsv(
-    metadata_only,
+    metadata_only %>% sanitize_for_cache(),
     file.path(output_directory, filename),
     col_names = FALSE,
     na = '',
@@ -544,7 +544,7 @@ export_attributes_to_vdi <- function(entities, output_directory, install_json, s
   filename <- glue("{tablename}.cache")
   # `escape = 'none'` prevents doubling of double-quotes
   write_tsv(
-    attribute_values_data,
+    attribute_values_data %>% sanitize_for_cache(),
     file.path(output_directory, filename),
     col_names = FALSE,
     na = '',
@@ -625,13 +625,13 @@ export_collections_to_vdi <- function(entities, output_directory, install_json, 
   filename <- glue("{tablename}.cache")
   # `escape = 'none'` prevents doubling of double-quotes
   write_tsv(
-    metadata_only,
+    metadata_only %>% sanitize_for_cache(),
     file.path(output_directory, filename),
     col_names = FALSE,
     na = '',
     escape = 'none'
   )
-  
+
   # set `maxLength` to max from data for all type="SQL_VARCHAR"
   # in `collections_table_fields` before adding to `install_json`
   # also similar treatment for `prec` field for "SQL_NUMBER" fields
@@ -671,7 +671,7 @@ export_collections_to_vdi <- function(entities, output_directory, install_json, 
   
   # write the data
   write_tsv(
-    collectionattributes,
+    collectionattributes %>% sanitize_for_cache(),
     file.path(output_directory, collectionattributes_filename),
     col_names = FALSE,
     na = '',
@@ -705,5 +705,14 @@ jsonify_list_column <- function(x) {
   } else {
     as.character(jsonlite::toJSON(unlist(x)))
   }
+}
+
+# Replace characters that would corrupt the TSV-based VDI import format.
+# Newlines/carriage returns/tabs are replaced with a single space.
+# Backticks are replaced with single quotes (Postgres loader uses backtick as quote char).
+sanitize_for_cache <- function(df) {
+  df %>% mutate(across(where(is.character), function(x) {
+    gsub("`", "'", gsub("[\n\r\t]", " ", x), fixed = TRUE)
+  }))
 }
 

--- a/R/entity-validators-eda-basic.R
+++ b/R/entity-validators-eda-basic.R
@@ -151,6 +151,9 @@ validate_entity_string_value_length <- function(entity) {
 #' Newlines in string values corrupt the TSV-based VDI import format.
 #' For multi-valued columns, checking the raw (unsplit) cell is sufficient:
 #' if no raw cell contains a newline, no component can either.
+#'
+#' DEPRECATED/UNUSED
+#'
 #' @keywords internal
 validate_entity_string_value_newlines <- function(entity) {
   data <- entity@data

--- a/R/validators.R
+++ b/R/validators.R
@@ -221,8 +221,9 @@ list_validators <- function() {
   register_validator("eda_string_value_length", validate_entity_string_value_length,
                     "entity", "eda", "Check string values do not exceed 1000 characters")
 
-  register_validator("eda_string_value_newlines", validate_entity_string_value_newlines,
-                    "entity", "eda", "Check string values do not contain newline characters")
+  ### RETIRED in favour of replacing newlines and tabs with single spaces in Study-export-VDI.R
+  #  register_validator("eda_string_value_newlines", validate_entity_string_value_newlines,
+  #                    "entity", "eda", "Check string values do not contain newline characters")
 
   # Study-level EDA validators
   register_validator("study_unique_entity_stable_ids", validate_study_unique_entity_stable_ids,

--- a/tests/testthat/helper-make_study.R
+++ b/tests/testthat/helper-make_study.R
@@ -61,6 +61,25 @@ make_minimal_stf <- function(output_directory) {
   
 }
 
+make_study_with_tabs_data <- function(quiet_entities = TRUE, ...) {
+  metadata <- list(...)
+  validate_object_metadata_names('Study', metadata)
+
+  households_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+
+  # dirty_notes has embedded tabs, a newline, and a backtick.
+  # Two rows share the same value so the column isn't auto-detected as an ID.
+  households <- entity_from_file(households_path, name="household", quiet=quiet_entities) %>%
+    modify_data(mutate(
+      dirty_notes = c("has\ta tab\nand a `backtick`", "also\ta tab", "has\ta tab\nand a `backtick`")
+    )) %>%
+    sync_variable_metadata()
+
+  args <- c(list(entities = list(households)), metadata)
+  study <- do.call(study_from_entities, args)
+  return(study)
+}
+
 make_study_with_collections <- function(quiet_entities = TRUE, ...) {
   study <- make_study(quiet_entities, ...)
 

--- a/tests/testthat/test-Study-export-VDI.R
+++ b/tests/testthat/test-Study-export-VDI.R
@@ -131,3 +131,49 @@ test_that("A study with collections exports to VDI", {
   # Clean up
   unlink(output_dir, recursive = TRUE)
 })
+
+test_that("Tabs, newlines and backticks in string values are sanitized in VDI cache files", {
+  study <- make_study_with_tabs_data(name = 'tabs test study')
+
+  output_dir <- "./tmp/vdi-tabs"
+
+  expect_no_error(
+    capture_messages(study %>% export_to_vdi(output_directory = output_dir))
+  )
+
+  cache_files <- list.files(output_dir, pattern = "\\.cache$", full.names = TRUE)
+  # study.cache is intentionally not sanitized (controlled IDs only)
+  data_cache_files <- cache_files[basename(cache_files) != "study.cache"]
+
+  # The dirty_notes column in the test fixture has values containing embedded tabs,
+  # a newline, and a backtick.  After sanitization those characters should be gone.
+  # Check the attributevalue cache where string data lands.
+  av_file <- cache_files[grepl("^attributevalue", basename(cache_files))]
+  expect_equal(length(av_file), 1)
+  av_lines <- readLines(av_file)
+
+  # Original tab-in-value pattern must not be present
+  expect_false(any(grepl("has\ta", av_lines, fixed = TRUE)),
+               info = "Embedded tab survived into attributevalue cache")
+
+  # Sanitized value (tab replaced by space) must be present
+  expect_true(any(grepl("has a tab", av_lines, fixed = TRUE)),
+              info = "Expected space-for-tab substitution not found in attributevalue cache")
+
+  # Backticks must be replaced by single quotes
+  expect_false(any(grepl("`", av_lines, fixed = TRUE)),
+               info = "Backtick found in attributevalue cache")
+  expect_true(any(grepl("'backtick'", av_lines, fixed = TRUE)),
+              info = "Expected single-quote replacement not found in attributevalue cache")
+
+  # No embedded carriage returns should survive into any data cache file
+  for (f in data_cache_files) {
+    lines <- readLines(f)
+    expect_false(
+      any(grepl("\r", lines, fixed = TRUE)),
+      info = paste("Embedded carriage return found in", basename(f))
+    )
+  }
+
+  unlink(output_dir, recursive = TRUE)
+})


### PR DESCRIPTION
Also disable the "no newlines" validation check for the EDA layer.

New tests added, all looks good. Going to merge.