### PR TITLE
Add empty row skipping and tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: study.wrangler
 Title: Wrangle (Tidy) Study Data
-Version: 1.0.45
+Version: 1.0.46
 Authors@R:
     c(person(given = "Bob",
            family = "MacCallum",

--- a/R/entity_from_file.R
+++ b/R/entity_from_file.R
@@ -5,6 +5,12 @@
 #' This function infers variables' metadata, including data types and shapes,
 #' and allows for pre-processing of the raw data before type inference.
 #'
+#' Fully empty rows and columns are silently cleaned up during import: any row
+#' or column whose values are all missing or blank is dropped (a cell counts as
+#' empty if it is `NA` or contains only whitespace). This removes stray
+#' delimiter-only rows (e.g. a bare `"\\t\\t\\t"` line) that would otherwise be
+#' imported as spurious all-missing records.
+#'
 #' @param file_path A string specifying the path to the input file.
 #' @param preprocess_fn An optional function to modify the raw data
 #'   before type inference. This can be used for tasks such as correcting
@@ -71,6 +77,11 @@ entity_from_file <- function(file_path, preprocess_fn = NULL, ...) {
 #'
 #' @description
 #' Creates an Entity object from a raw character-only tibble. Optionally applies a preprocessing function.
+#'
+#' Fully empty rows and columns are dropped: any row or column whose values are
+#' all missing or blank is removed (a cell counts as empty if it is `NA` or
+#' contains only whitespace). A message reports how many were dropped unless
+#' `quiet = TRUE` is passed.
 #' @param data A tibble with all columns as character (unless skip_type_convert is TRUE)
 #' @param preprocess_fn Optional function to preprocess the tibble before type inference.
 #'   If the input has duplicate column names, they are deduplicated (e.g. `notes`, `notes.1`)
@@ -130,6 +141,26 @@ entity_from_tibble <- function(data, preprocess_fn = NULL, skip_type_convert = F
       )
     }
     data <- data[, -empty_data_indices, drop = FALSE]
+  }
+
+  # Drop fully empty rows, and inform the user. The file readers pass
+  # skip_empty_rows = FALSE, so blank lines (including bare-delimiter rows like
+  # "\t\t\t") arrive here as all-NA rows for us to handle uniformly. As with
+  # empty columns, a cell counts as empty if it is NA or contains only whitespace.
+  if (nrow(data) > 0) {
+    empty_row_mask <- apply(data, 1, function(row) {
+      all(is.na(row) | trimws(as.character(row)) == "")
+    })
+    n_empty_rows <- sum(empty_row_mask)
+    if (n_empty_rows > 0) {
+      if (!isTRUE(metadata$quiet)) {
+        message(
+          "Dropped ", n_empty_rows,
+          " empty row(s) (all values missing or blank)"
+        )
+      }
+      data <- data[!empty_row_mask, , drop = FALSE]
+    }
   }
 
   # Build a map from deduplicated name → original name so provider_label
@@ -220,6 +251,11 @@ entity_from_tsv <- function(file_path, preprocess_fn = NULL, ...) {
       name_repair = 'minimal',
       col_types = readr::cols(.default = "c"),
       locale = readr::locale(encoding = enc),
+      # Keep blank lines so our own empty-row handling in entity_from_tibble()
+      # reports them consistently, rather than relying on readr's delimiter- and
+      # format-dependent skipping (e.g. read_tsv skips a bare-tab row but
+      # read_csv keeps a bare-comma row).
+      skip_empty_rows = FALSE,
       progress = FALSE
     )
   )
@@ -247,6 +283,8 @@ entity_from_csv <- function(file_path, preprocess_fn = NULL, ...) {
       name_repair = 'minimal',
       col_types = readr::cols(.default = "c"),
       locale = readr::locale(encoding = enc),
+      # See note in entity_from_tsv(): keep blank lines for consistent handling.
+      skip_empty_rows = FALSE,
       progress = FALSE
     )
   )

--- a/inst/extdata/toy_example/householdsWithEmptyRow.csv
+++ b/inst/extdata/toy_example/householdsWithEmptyRow.csv
@@ -1,0 +1,5 @@
+Household Id,Number of animals,Owns property,Enrollment date,Construction material
+H001,4,Yes,2021-01-09,Concrete
+H002,3,No,2021-02-28,Timber
+,,,,
+H003,3,Yes,2021-03-13,Concrete

--- a/inst/extdata/toy_example/householdsWithEmptyRow.tsv
+++ b/inst/extdata/toy_example/householdsWithEmptyRow.tsv
@@ -1,0 +1,5 @@
+Household Id	Number of animals	Owns property	Enrollment date	Construction material
+H001	4	Yes	2021-01-09	Concrete
+H002	3	No	2021-02-28	Timber
+				
+H003	3	Yes	2021-03-13	Concrete

--- a/tests/testthat/test-entity_from_file.R
+++ b/tests/testthat/test-entity_from_file.R
@@ -201,3 +201,75 @@ test_that("entity_from_tibble keeps columns that have at least one non-empty val
   expect_equal(ncol(result@data), 2)
 })
 
+test_that("entity_from_tibble drops fully empty rows with a message", {
+  data <- tibble::tibble(
+    id    = c("A", NA, "B"),
+    value = c("1", NA, "2")
+  )
+  expect_message(
+    result <- entity_from_tibble(data),
+    "Dropped 1 empty row\\(s\\)"
+  )
+  expect_equal(nrow(result@data), 2)
+  expect_equal(result@data$id, c("A", "B"))
+})
+
+test_that("entity_from_tibble treats whitespace-only rows as empty", {
+  data <- tibble::tibble(
+    id    = c("A", "  ", "B"),
+    value = c("1", "", "2")
+  )
+  expect_message(
+    result <- entity_from_tibble(data),
+    "Dropped 1 empty row\\(s\\)"
+  )
+  expect_equal(nrow(result@data), 2)
+})
+
+test_that("entity_from_tibble suppresses empty-row message when quiet = TRUE", {
+  data <- tibble::tibble(
+    id    = c("A", NA, "B"),
+    value = c("1", NA, "2")
+  )
+  expect_silent(
+    result <- entity_from_tibble(data, quiet = TRUE)
+  )
+  expect_equal(nrow(result@data), 2)
+})
+
+test_that("entity_from_tibble keeps rows that have at least one non-empty value", {
+  data <- tibble::tibble(
+    id    = c("A", "B", "C"),
+    value = c("1", NA, NA)
+  )
+  expect_silent(
+    result <- entity_from_tibble(data)
+  )
+  expect_equal(nrow(result@data), 3)
+})
+
+test_that("entity_from_file strips an empty data row (smoke test)", {
+  # Both fixtures are the households data with a bare-delimiter empty row: a
+  # tab-only row in the TSV and a comma-only row in the CSV. readr skips these
+  # inconsistently by default, but because we read with skip_empty_rows = FALSE
+  # both reach our own empty-row handling and are dropped with a message,
+  # leaving the same result as the clean households file.
+  households_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+  reference <- entity_from_file(households_path, name = "household")
+
+  for (ext in c("tsv", "csv")) {
+    file_path <- system.file("extdata", paste0("toy_example/householdsWithEmptyRow.", ext), package = 'study.wrangler')
+
+    expect_message(
+      result <- entity_from_file(file_path, name = "household"),
+      "Dropped 1 empty row\\(s\\)"
+    )
+
+    expect_equal(nrow(result@data), nrow(reference@data))
+    expect_equal(result@data, reference@data)
+    expect_equal(result@variables$data_type, reference@variables$data_type)
+
+    expect_true(result %>% quiet() %>% validate())
+  }
+})
+


### PR DESCRIPTION
Fixes #86 

**Root cause:** `readr` skips blank lines inconsistently — `read_tsv` drops a bare-tab row (`\t\t`) but `read_csv` keeps a bare-comma row (`,,,,`). So an "empty" row in a CSV (like the reported `Australia_Dolphins.csv`) leaks into the data as an all-NA record, while the equivalent TSV row silently vanishes.

**Fix** (`R/entity_from_file.R`):
1. Both readers now pass `skip_empty_rows = FALSE`, so *every* blank line reaches our own code instead of relying on readr's format-dependent behaviour.
2. Added empty-**row** dropping in `entity_from_tibble()`, right beside the existing empty-**column** / ghost-column handling — a row is dropped if every cell is `NA` or whitespace-only, with a `Dropped N empty row(s)` message (suppressed by `quiet = TRUE`), mirroring the column logic exactly.

**Tests**

* two new fixture files (csv+tsv) with an all empty row
* further fine-grained tests using `entity_from_tibble` directly