### PR TITLE
Fix false parse-error on truly blank lines in CSV/TSV import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: study.wrangler
 Title: Wrangle (Tidy) Study Data
-Version: 1.0.46
+Version: 1.0.47
 Authors@R:
     c(person(given = "Bob",
            family = "MacCallum",

--- a/R/entity_from_file.R
+++ b/R/entity_from_file.R
@@ -240,6 +240,21 @@ detect_file_encoding <- function(path) {
   if (has_windows_range) "Windows-1252" else "ISO-8859-1"
 }
 
+# A truly blank line (as opposed to a bare-delimiter row) parses as a single
+# empty field, one column short of the header count, which readr flags as a
+# parsing "problem" even though it pads the row out to all-NA underneath.
+# That all-NA row is exactly what entity_from_tibble()'s empty-row cleanup is
+# meant to catch, so it isn't a real problem; drop it before deciding whether
+# to fail on genuinely malformed rows (e.g. truncated data with real values).
+drop_blank_line_problems <- function(problems, data) {
+  if (nrow(problems) == 0) return(problems)
+  is_blank_line_row <- vapply(problems$row, function(r) {
+    row_values <- unlist(data[r, ], use.names = FALSE)
+    all(is.na(row_values) | trimws(row_values) == "")
+  }, logical(1))
+  problems[!is_blank_line_row, , drop = FALSE]
+}
+
 #' entity_from_tsv
 #' @description Convenience function to create an Entity from a TSV file.
 #' @export
@@ -259,7 +274,7 @@ entity_from_tsv <- function(file_path, preprocess_fn = NULL, ...) {
       progress = FALSE
     )
   )
-  problems <- readr::problems(data)
+  problems <- drop_blank_line_problems(readr::problems(data), data)
   if (nrow(problems) > 0) {
     stop(paste0(
       c(
@@ -288,7 +303,7 @@ entity_from_csv <- function(file_path, preprocess_fn = NULL, ...) {
       progress = FALSE
     )
   )
-  problems <- readr::problems(data)
+  problems <- drop_blank_line_problems(readr::problems(data), data)
   if (nrow(problems) > 0) {
     stop(paste0(
       c(

--- a/inst/extdata/toy_example/householdsWithBlankLine.csv
+++ b/inst/extdata/toy_example/householdsWithBlankLine.csv
@@ -1,0 +1,5 @@
+Household Id,Number of animals,Owns property,Enrollment date,Construction material
+H001,4,Yes,2021-01-09,Concrete
+H002,3,No,2021-02-28,Timber
+
+H003,3,Yes,2021-03-13,Concrete

--- a/inst/extdata/toy_example/householdsWithBlankLine.tsv
+++ b/inst/extdata/toy_example/householdsWithBlankLine.tsv
@@ -1,0 +1,5 @@
+Household Id	Number of animals	Owns property	Enrollment date	Construction material
+H001	4	Yes	2021-01-09	Concrete
+H002	3	No	2021-02-28	Timber
+
+H003	3	Yes	2021-03-13	Concrete

--- a/tests/testthat/test-entity_from_file.R
+++ b/tests/testthat/test-entity_from_file.R
@@ -273,3 +273,30 @@ test_that("entity_from_file strips an empty data row (smoke test)", {
   }
 })
 
+test_that("entity_from_file strips a truly blank line, not just a bare-delimiter row", {
+  # Unlike householdsWithEmptyRow.*, these fixtures have a zero-length blank
+  # line rather than a delimiter-only row. readr (with skip_empty_rows =
+  # FALSE) parses a blank line as a single empty field, which is one fewer
+  # column than expected, and records this as a parsing "problem" even though
+  # the row itself parses fine as all-NA. That problem must not be treated as
+  # a fatal parse error, since the all-NA row is legitimately handled by our
+  # own empty-row cleanup.
+  households_path <- system.file("extdata", "toy_example/households.tsv", package = 'study.wrangler')
+  reference <- entity_from_file(households_path, name = "household")
+
+  for (ext in c("tsv", "csv")) {
+    file_path <- system.file("extdata", paste0("toy_example/householdsWithBlankLine.", ext), package = 'study.wrangler')
+
+    expect_message(
+      result <- entity_from_file(file_path, name = "household"),
+      "Dropped 1 empty row\\(s\\)"
+    )
+
+    expect_equal(nrow(result@data), nrow(reference@data))
+    expect_equal(result@data, reference@data)
+    expect_equal(result@variables$data_type, reference@variables$data_type)
+
+    expect_true(result %>% quiet() %>% validate())
+  }
+})
+


### PR DESCRIPTION
A zero-length blank line parses as one column short of the header count, which readr records as a parsing "problem" even though the row is padded to all-NA underneath. entity_from_tsv()/entity_from_csv() treated any readr problem as fatal, so blank lines threw despite being exactly the case entity_from_tibble()'s empty-row cleanup already handles (unlike bare-delimiter rows, which parse with the right column count and never triggered this). Filter out all-blank rows before failing on genuine parsing issues.